### PR TITLE
Fixed sand replacing non-buildable-to nodes on place

### DIFF
--- a/minetestforfun_game/mods/default/nodes.lua
+++ b/minetestforfun_game/mods/default/nodes.lua
@@ -273,6 +273,30 @@ minetest.register_abm({
 	end
 })
 
+local function sand_on_place(itemstack, placer, pointed_thing)
+	if not pointed_thing.type == "node" then
+		return itemstack
+	end
+	local pn = placer:get_player_name()
+	if minetest.is_protected(pointed_thing.above, pn) then
+		return itemstack
+	end
+	local node = minetest.get_node(pointed_thing.above)
+	local def = minetest.registered_nodes[node.name]
+	if def and def.buildable_to then
+		minetest.add_node(pointed_thing.above, {name=itemstack:get_name()})
+		local meta = minetest.get_meta(pointed_thing.above)
+		meta:set_string("owner", pn)
+		nodeupdate(pointed_thing.above)
+		if not minetest.setting_getbool("creative_mode") then
+			itemstack:take_item()
+		end
+		return itemstack
+	else
+		return itemstack
+	end
+end
+
 minetest.register_node("default:sand", {
 	description = "Sand",
 	tiles = {"default_sand.png"},
@@ -284,23 +308,7 @@ minetest.register_node("default:sand", {
 	},
 	groups = {crumbly = 3, falling_node = 1, sand = 1},
 	sounds = default.node_sound_sand_defaults(),
-	on_place = function(itemstack, placer, pointed_thing)
-     		if not pointed_thing.type == "node" then
-			return itemstack
-		end
-		local pn = placer:get_player_name()
-		if minetest.is_protected(pointed_thing.above, pn) then
-			return itemstack
-		end
-		minetest.add_node(pointed_thing.above, {name=itemstack:get_name()})
-		local meta = minetest.get_meta(pointed_thing.above)
-		meta:set_string("owner", pn)
-		nodeupdate(pointed_thing.above)
-		if not minetest.setting_getbool("creative_mode") then
-				itemstack:take_item()
-		end
-		return itemstack
-	end
+	on_place = sand_on_place
 })
 
 minetest.register_node("default:desert_sand", {
@@ -314,23 +322,7 @@ minetest.register_node("default:desert_sand", {
 	},
 	groups = {crumbly = 3, falling_node = 1, sand = 1},
 	sounds = default.node_sound_sand_defaults(),
-	on_place = function(itemstack, placer, pointed_thing)
-     		if not pointed_thing.type == "node" then
-			return itemstack
-		end
-		local pn = placer:get_player_name()
-		if minetest.is_protected(pointed_thing.above, pn) then
-			return itemstack
-		end
-		minetest.add_node(pointed_thing.above, {name=itemstack:get_name()})
-		local meta = minetest.get_meta(pointed_thing.above)
-		meta:set_string("owner", pn)
-		nodeupdate(pointed_thing.above)
-		if not minetest.setting_getbool("creative_mode") then
-				itemstack:take_item()
-		end
-		return itemstack
-	end
+	on_place = sand_on_place
 })
 
 minetest.register_node("default:gravel", {
@@ -344,23 +336,7 @@ minetest.register_node("default:gravel", {
 		},
 	},
 	sounds = default.node_sound_gravel_defaults(),
-	on_place = function(itemstack, placer, pointed_thing)
-     		if not pointed_thing.type == "node" then
-			return itemstack
-		end
-		local pn = placer:get_player_name()
-		if minetest.is_protected(pointed_thing.above, pn) then
-			return itemstack
-		end
-		minetest.add_node(pointed_thing.above, {name=itemstack:get_name()})
-		local meta = minetest.get_meta(pointed_thing.above)
-		meta:set_string("owner", pn)
-		nodeupdate(pointed_thing.above)
-		if not minetest.setting_getbool("creative_mode") then
-				itemstack:take_item()
-		end
-		return itemstack
-	end
+	on_place = sand_on_place
 })
 
 minetest.register_node("default:sandstone", {


### PR DESCRIPTION
J'ai corrigé un problème que j'ai remarqué il y a déjà une ou deux semaines. Quand on prend un bloc de sable en main, et qu'on fait clic droit quelque part pour placer le sable, sur un bloc déjà occupé, il se place quand même, faisant disparaître l'ancien bloc.
Je viens de corriger ceci.