### PR TITLE
Added sethome handlers using minetest.[de]serialize

### DIFF
--- a/minetestforfun_game/mods/sethome/init.lua
+++ b/minetestforfun_game/mods/sethome/init.lua
@@ -30,9 +30,6 @@ home.sethome = function(name)
 		home.homepos[p_status][player:get_player_name()] = pos
 		minetest.chat_send_player(name, "Home set!")
 		local output = io.open(home.homes_file[p_status], "w")
-		--for i, v in pairs(home.homepos[p_status]) do
-		--	output:write(v.x.." "..v.y.." "..v.z.." "..i.."\n")
-		--end
 		output:write(minetest.serialize(home.homepos[p_status]))
 		io.close(output)
 		return true


### PR DESCRIPTION
minetest.serialize and minetest.deserialize provide a faster way to write and read input,
it turnes useless the repeat .. until statement, and then, make the read faster.
It also adds the real/nether timers, which will be commited in a few minutes, so I will probably need to rebase.