### PR TITLE
Added "default:cherry_tree" to mapgen.

### DIFF
--- a/minetestforfun_game/mods/default/mapgen.lua
+++ b/minetestforfun_game/mods/default/mapgen.lua
@@ -726,6 +726,23 @@ function default.register_mgv6_decorations()
 		y_max = 30,
 		decoration = "default:dry_shrub",
 	})
+
+	-- Cherry tree
+	minetest.register_decoration({
+		deco_type = "simple",
+		place_on = "default:dirt_with_grass",
+		sidelen = 16,
+		noise_params = {
+			offset = 0,
+			scale = 0.005,
+			spread = {x=100, y=100, z=100},
+			seed = 278,
+			octaves = 2,
+			persist = 0.7
+		},
+		decoration = "default:mg_cherry_sapling",
+		height = 1,
+	})
 end
 
 


### PR DESCRIPTION
Les "default:cherry_tree" n'étaient jamais genérés. Voici une façon de le faire. 

Les "noise_params" permettent de les générer sous forme de petits bois. Le champ "scale" semble être la densité d'arbres. Plus il est elevé, plus il y a d'arbres et de lag pour les faire pousser. J'ai mis les paramètres qui me plaisaient le plus dans mes tests. 

Je ne suis pas un expert de mapgen. D'autres personnes devraient essayer de jouer avec ces paramatres en singleplayer. On peut ajouter des y_min et y_max aussi pour les generer uniquement à certaines hauteurs. 